### PR TITLE
chore: use base node14 tsconfig

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,11 @@ module.exports = {
       'error',
       { argsIgnorePattern: '^_', caughtErrors: 'all' },
     ],
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      { fixStyle: 'inline-type-imports', disallowTypeAnnotations: false },
+    ],
+    '@typescript-eslint/no-import-type-side-effects': 'error',
     'no-else-return': 'error',
     'no-negated-condition': 'error',
     eqeqeq: ['error', 'smart'],

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@jest/types": "^29.0.2",
     "@semantic-release/changelog": "^6.0.0",
     "@semantic-release/git": "^10.0.0",
+    "@tsconfig/node14": "^14.1.2",
     "@types/jest": "^29.0.0",
     "@types/node": "^16.0.0",
     "@types/react": "^17.0.39",

--- a/src/Reporter.tsx
+++ b/src/Reporter.tsx
@@ -1,14 +1,22 @@
 import * as path from 'path';
 import * as React from 'react';
-import { Box, Static, Text, TextProps, render, useApp, useStdout } from 'ink';
+import {
+  Box,
+  Static,
+  Text,
+  type TextProps,
+  render,
+  useApp,
+  useStdout,
+} from 'ink';
 import slash = require('slash');
 import type { Config } from '@jest/types';
 import type { AggregatedResult, TestResult } from '@jest/test-result';
 import {
   BaseReporter,
-  ReporterOnStartOptions,
-  Test,
-  TestContext,
+  type ReporterOnStartOptions,
+  type Test,
+  type TestContext,
 } from '@jest/reporters';
 import { SnapshotStatus } from './SnapshotStatus';
 import { Summary } from './Summary';

--- a/src/shared.tsx
+++ b/src/shared.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Box, Text, TextProps } from 'ink';
+import { Box, Text, type TextProps } from 'ink';
 import type { TestResult } from '@jest/test-result';
 import type { Config } from '@jest/types';
 import chalk = require('chalk');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,11 @@
 {
+  "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
-    "lib": ["es2017", "dom"],
-    "target": "es2017",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "skipLibCheck": false,
     "jsx": "react",
     "declaration": false,
     "isolatedModules": true,
-    "importsNotUsedAsValues": "error",
     "noImplicitReturns": true,
-    "strict": true,
     // ink requires this
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1618,6 +1618,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tsconfig/node14@npm:^14.1.2":
+  version: 14.1.2
+  resolution: "@tsconfig/node14@npm:14.1.2"
+  checksum: f5934cebc6c8790b28a145d8abbafcb0bd23a405ebcb790bd9f524a2750757d5675b418583bddaed760894a18a0a59a8cbfec1979c90e388d7ad784a9519193f
+  languageName: node
+  linkType: hard
+
 "@tufjs/canonical-json@npm:2.0.0":
   version: 2.0.0
   resolution: "@tufjs/canonical-json@npm:2.0.0"
@@ -5591,6 +5598,7 @@ __metadata:
     "@jest/types": ^29.0.2
     "@semantic-release/changelog": ^6.0.0
     "@semantic-release/git": ^10.0.0
+    "@tsconfig/node14": ^14.1.2
     "@types/jest": ^29.0.0
     "@types/node": ^16.0.0
     "@types/react": ^17.0.39


### PR DESCRIPTION
These are the changes from #219 that can land without dropping node 14.